### PR TITLE
proxied requests require auth so include the credentials

### DIFF
--- a/dist/story-tools-edit-ng.js
+++ b/dist/story-tools-edit-ng.js
@@ -666,7 +666,7 @@
                 // this is an exchange assumption, and assumes SLD
                 style_href = style_href.replace('.json', '.sld');
 
-                fetch(style_href).then(function(r) {
+                fetch(style_href, {credentials: 'include'}).then(function(r) {
                   r.text().then(function(sldText) {
                     var parser = new DOMParser();
                     var sld_doc = parser.parseFromString(sldText, 'application/xml');

--- a/dist/story-tools-edit-ng.js
+++ b/dist/story-tools-edit-ng.js
@@ -666,7 +666,7 @@
                 // this is an exchange assumption, and assumes SLD
                 style_href = style_href.replace('.json', '.sld');
 
-                fetch(style_href, {credentials: 'include'}).then(function(r) {
+                fetch(style_href, {credentials: 'same-origin'}).then(function(r) {
                   r.text().then(function(sldText) {
                     var parser = new DOMParser();
                     var sld_doc = parser.parseFromString(sldText, 'application/xml');

--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -210,7 +210,7 @@
                 // this is an exchange assumption, and assumes SLD
                 style_href = style_href.replace('.json', '.sld');
 
-                fetch(style_href).then(function(r) {
+                fetch(style_href, {credentials: 'include'}).then(function(r) {
                   r.text().then(function(sldText) {
                     var parser = new DOMParser();
                     var sld_doc = parser.parseFromString(sldText, 'application/xml');

--- a/lib/ng/edit/style/controllers/controllers.js
+++ b/lib/ng/edit/style/controllers/controllers.js
@@ -210,7 +210,7 @@
                 // this is an exchange assumption, and assumes SLD
                 style_href = style_href.replace('.json', '.sld');
 
-                fetch(style_href, {credentials: 'include'}).then(function(r) {
+                fetch(style_href, {credentials: 'same-origin'}).then(function(r) {
                   r.text().then(function(sldText) {
                     var parser = new DOMParser();
                     var sld_doc = parser.parseFromString(sldText, 'application/xml');


### PR DESCRIPTION
This PR fixes a bug where the proxied requests to Exchange were resulting in a 302 to the login page rather than a 200 returning the requested sld.